### PR TITLE
7-zip 15.14 and archive extract test

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,4 +13,4 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[seven_zip]
+      - recipe[test_archive]

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,7 @@
 source 'https://supermarket.chef.io'
 
 metadata
+
+group :integration do
+  cookbook 'test_archive', path: 'test/fixtures/cookbooks/test_archive'
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,13 +19,13 @@
 #
 
 if kernel['machine'] =~ /x86_64/
-  default['seven_zip']['url']          = 'http://www.7-zip.org/a/7z920-x64.msi'
-  default['seven_zip']['checksum']     = '62df458bc521001cd9a947643a84810ecbaa5a16b5c8e87d80df8e34c4a16fe2'
-  default['seven_zip']['package_name'] = '7z920-x64.msi'
+  default['seven_zip']['url']          = 'http://www.7-zip.org/a/7z1514-x64.msi'
+  default['seven_zip']['checksum']     = 'cefe1a9092d8a6be68468c33910d6206b40e934fb63cab686c5cccf369fbf712'
+  default['seven_zip']['package_name'] = '7-zip 15.14 (x64 edition)'
 else
-  default['seven_zip']['url']          = 'http://www.7-zip.org/a/7z920.msi'
-  default['seven_zip']['checksum']     = 'fe4807b4698ec89f82de7d85d32deaa4c772fc871537e31fb0fccf4473455cb8'
-  default['seven_zip']['package_name'] = '7z920.msi'
+  default['seven_zip']['url']          = 'http://www.7-zip.org/a/7z1514.msi'
+  default['seven_zip']['checksum']     = 'eaf58e29941d8ca95045946949d75d9b5455fac167df979a7f8e4a6bf2d39680'
+  default['seven_zip']['package_name'] = '7-zip 15.14'
 end
 
 default['seven_zip']['home'] = "#{ENV['SYSTEMDRIVE']}\\7-zip"

--- a/test/fixtures/cookbooks/test_archive/attributes/default.rb
+++ b/test/fixtures/cookbooks/test_archive/attributes/default.rb
@@ -1,0 +1,4 @@
+default['test_archive']['path']      = 'C:\seven_zip_source'
+default['test_archive']['source']    = 'http://www.7-zip.org/a/7z1514-src.7z'
+default['test_archive']['overwrite'] = true
+default['test_archive']['checksum']  = '3713aed72728eae8f6649e4803eba0b3676785200c76df6269034c520df4bbd5'

--- a/test/fixtures/cookbooks/test_archive/metadata.rb
+++ b/test/fixtures/cookbooks/test_archive/metadata.rb
@@ -1,0 +1,3 @@
+name    'test_archive'
+version '1.0.0'
+depends 'seven_zip'

--- a/test/fixtures/cookbooks/test_archive/recipes/default.rb
+++ b/test/fixtures/cookbooks/test_archive/recipes/default.rb
@@ -1,0 +1,9 @@
+# This recipe is for testing the seven_zip archive provider
+include_recipe 'seven_zip'
+
+seven_zip_archive 'test_archive' do
+  path      node['test_archive']['path']
+  source    node['test_archive']['source']
+  overwrite node['test_archive']['overwrite']
+  checksum  node['test_archive']['checksum']
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe package('7-zip 9.20 (x64 edition)') do
+describe package('7-zip 15.14 (x64 edition)') do
   it { should be_installed }
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,5 +1,17 @@
 require 'spec_helper'
 
 describe package('7-zip 15.14 (x64 edition)') do
-  it { should be_installed }
+  it 'is installed' do
+    expect(subject).to be_installed
+  end
+end
+
+describe file('C:\seven_zip_source') do
+  it 'is a directory' do
+    expect(subject).to be_directory
+  end
+
+  it 'should contain only extracted files' do
+    expect(Dir.entries(subject.name).sort).to eq %w(. .. Asm C CPP DOC)
+  end
 end


### PR DESCRIPTION
Hi,
This bumps the version of 7-zip to the latest stable and adds a test cookbook + ServerSpec test to test the extraction of a 7z file.