### PR TITLE
Make install location and syspath optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Requirements
 - Windows Server 2012 (R1, R2)
 
 ### Chef
-- Chef 11+
+- Chef >= 11.6
 
 ### Cookbooks
 - windows

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Attributes
 
 Resource/Provider
 -----------------
-### zeven_zip_archive
+### seven_zip_archive
 
 Extracts a 7-zip compatible archive (iso, zip, 7z etc) to the specified destination directory.
 
@@ -42,17 +42,16 @@ Extracts a 7-zip compatible archive (iso, zip, 7z etc) to the specified destinat
 - `checksum` - The archive file checksum.
 
 #### Examples
-Extract VisualStudio ISO files to c:/vs2015tmp
+Extract 7-zip source files to `C:\seven_zip_source`.
 
 ```ruby
-seven_zip_archive 'extract_vs2015_iso' do
-  path 'c:/vs2015tmp'
-  source 'http://example.com/vs2015.iso'
+seven_zip_archive 'seven_zip_source' do
+  path      'C:\seven_zip_source'
+  source    'http://www.7-zip.org/a/7z1514-src.7z'
   overwrite true
-  checksum '44db74d1e6243924c187069ad95cee58b687dcb9ba2d302fc6ae889fb4ae7694'
+  checksum  '3713aed72728eae8f6649e4803eba0b3676785200c76df6269034c520df4bbd5'
 end
 ```
-
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Requirements
 
 Attributes
 ----------
-- `node['seven_zip']['home']` - location to install 7-zip files to.  default is `%SYSTEMDRIVE%\7-zip`
-
+- (optional) `node['seven_zip']['home']` - specify location for 7-zip installation.
+- (optional) `node['seven_zip']['syspath']` - if true, adds 7-zip directory to system path.
 
 Resource/Provider
 -----------------
@@ -57,8 +57,7 @@ end
 Usage
 -----
 ### default
-Downloads and installs 7-zip to the location specified by `node['seven_zip']['home']`.  Also ensures `node['seven_zip']['home']` is in the system path.
-
+Downloads and installs 7-zip.
 
 License & Authors
 -----------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,5 +27,3 @@ else
   default['seven_zip']['checksum']     = 'eaf58e29941d8ca95045946949d75d9b5455fac167df979a7f8e4a6bf2d39680'
   default['seven_zip']['package_name'] = '7-zip 15.14'
 end
-
-default['seven_zip']['home'] = "#{ENV['SYSTEMDRIVE']}\\7-zip"

--- a/providers/archive.rb
+++ b/providers/archive.rb
@@ -43,11 +43,16 @@ action :extract do
 end
 
 def seven_zip_exe
-  # Read path from recommended Windows App Paths registry location
-  # docs: https://msdn.microsoft.com/en-us/library/windows/desktop/ee872121
-  path = ::Win32::Registry::HKEY_LOCAL_MACHINE.open(
-    'SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\7zFM.exe',
-    ::Win32::Registry::KEY_READ).read_s('Path')
-  Chef::Log.debug("Found 7-zip home: #{path}")
+  path = if node['seven_zip']['home']
+           # If the installation home is specifically set, use it
+           node['seven_zip']['home']
+         else
+           # Read path from recommended Windows App Paths registry location
+           # docs: https://msdn.microsoft.com/en-us/library/windows/desktop/ee872121
+           ::Win32::Registry::HKEY_LOCAL_MACHINE.open(
+             'SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\7zFM.exe',
+             ::Win32::Registry::KEY_READ).read_s('Path')
+         end
+  Chef::Log.debug("Using 7-zip home: #{path}")
   win_friendly_path(::File.join(path, '7z.exe'))
 end

--- a/providers/archive.rb
+++ b/providers/archive.rb
@@ -19,6 +19,7 @@
 #
 
 require 'fileutils'
+require 'win32/registry'
 require 'chef/mixin/shell_out'
 
 include Chef::Mixin::ShellOut
@@ -42,6 +43,11 @@ action :extract do
 end
 
 def seven_zip_exe
-  Chef::Log.debug("seven zip home: #{node['seven_zip']['home']}")
-  win_friendly_path(::File.join(node['seven_zip']['home'], '7z.exe'))
+  # Read path from recommended Windows App Paths registry location
+  # docs: https://msdn.microsoft.com/en-us/library/windows/desktop/ee872121
+  path = ::Win32::Registry::HKEY_LOCAL_MACHINE.open(
+    'SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\7zFM.exe',
+    ::Win32::Registry::KEY_READ).read_s('Path')
+  Chef::Log.debug("Found 7-zip home: #{path}")
+  win_friendly_path(::File.join(path, '7z.exe'))
 end

--- a/providers/archive.rb
+++ b/providers/archive.rb
@@ -19,7 +19,6 @@
 #
 
 require 'fileutils'
-require 'win32/registry'
 require 'chef/mixin/shell_out'
 
 include Chef::Mixin::ShellOut
@@ -47,6 +46,7 @@ def seven_zip_exe
            # If the installation home is specifically set, use it
            node['seven_zip']['home']
          else
+           require 'win32/registry'
            # Read path from recommended Windows App Paths registry location
            # docs: https://msdn.microsoft.com/en-us/library/windows/desktop/ee872121
            ::Win32::Registry::HKEY_LOCAL_MACHINE.open(

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,9 +28,13 @@ end
 # update path
 windows_path 'seven_zip' do
   path lazy {
-    ::Win32::Registry::HKEY_LOCAL_MACHINE.open(
-      'SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\7zFM.exe',
-      ::Win32::Registry::KEY_READ).read_s('Path')
+    if node['seven_zip']['home']
+      node['seven_zip']['home']
+    else
+      ::Win32::Registry::HKEY_LOCAL_MACHINE.open(
+        'SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\7zFM.exe',
+        ::Win32::Registry::KEY_READ).read_s('Path')
+    end
   }
   action :add
 end if node['seven_zip']['syspath']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,11 +21,16 @@
 windows_package node['seven_zip']['package_name'] do
   source node['seven_zip']['url']
   checksum node['seven_zip']['checksum']
-  options "INSTALLDIR=\"#{node['seven_zip']['home']}\""
+  options "INSTALLDIR=\"#{node['seven_zip']['home']}\"" if node['seven_zip']['home']
   action :install
 end
 
 # update path
-windows_path node['seven_zip']['home'] do
+windows_path 'seven_zip' do
+  path lazy {
+    ::Win32::Registry::HKEY_LOCAL_MACHINE.open(
+      'SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\7zFM.exe',
+      ::Win32::Registry::KEY_READ).read_s('Path')
+  }
   action :add
-end
+end if node['seven_zip']['syspath']


### PR DESCRIPTION
This pull request includes #10.

There are two notable changes:
* Default installation location is left to the 7-zip installer (`C:\Program Files`)
* 7-zip directory is not added to the system path by default