### PR TITLE
Fix typo in package names

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,11 +21,11 @@
 if kernel['machine'] =~ /x86_64/
   default['seven_zip']['url']          = 'http://www.7-zip.org/a/7z1514-x64.msi'
   default['seven_zip']['checksum']     = 'cefe1a9092d8a6be68468c33910d6206b40e934fb63cab686c5cccf369fbf712'
-  default['seven_zip']['package_name'] = '7-zip 15.14 (x64 edition)'
+  default['seven_zip']['package_name'] = '7-Zip 15.14 (x64 edition)'
 else
   default['seven_zip']['url']          = 'http://www.7-zip.org/a/7z1514.msi'
   default['seven_zip']['checksum']     = 'eaf58e29941d8ca95045946949d75d9b5455fac167df979a7f8e4a6bf2d39680'
-  default['seven_zip']['package_name'] = '7-zip 15.14'
+  default['seven_zip']['package_name'] = '7-Zip 15.14'
 end
 
 default['seven_zip']['home'] = "#{ENV['SYSTEMDRIVE']}\\7-zip"


### PR DESCRIPTION
Fix a typo that impacts idempotency

cc: @aboten