### PR TITLE
Adds Timeout to Extraction Method

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,3 +27,5 @@ else
   default['seven_zip']['checksum']     = 'eaf58e29941d8ca95045946949d75d9b5455fac167df979a7f8e4a6bf2d39680'
   default['seven_zip']['package_name'] = '7-Zip 15.14'
 end
+
+default['seven_zip']['extract_timeout'] = 600

--- a/providers/archive.rb
+++ b/providers/archive.rb
@@ -39,7 +39,7 @@ action :extract do
     cmd << " -o\"#{win_friendly_path(@new_resource.path)}\""
     cmd << " \"#{local_source}\""
     Chef::Log.debug(cmd)
-    shell_out!(cmd)
+    shell_out!(cmd, timeout => @new_resource.timeout)
   end
 end
 

--- a/providers/archive.rb
+++ b/providers/archive.rb
@@ -39,7 +39,7 @@ action :extract do
     cmd << " -o\"#{win_friendly_path(@new_resource.path)}\""
     cmd << " \"#{local_source}\""
     Chef::Log.debug(cmd)
-    shell_out!(cmd, timeout => @new_resource.timeout)
+    shell_out!(cmd, timeout: node['seven_zip']['extract_timeout'])
   end
 end
 

--- a/resources/archive.rb
+++ b/resources/archive.rb
@@ -26,3 +26,4 @@ attribute :path, kind_of: String, name_attribute: true
 attribute :source, kind_of: String
 attribute :overwrite, kind_of: [TrueClass, FalseClass], default: false
 attribute :checksum, kind_of: String
+attribute :timeout, kind_of: Integer, default: 600

--- a/resources/archive.rb
+++ b/resources/archive.rb
@@ -26,4 +26,3 @@ attribute :path, kind_of: String, name_attribute: true
 attribute :source, kind_of: String
 attribute :overwrite, kind_of: [TrueClass, FalseClass], default: false
 attribute :checksum, kind_of: String
-attribute :timeout, kind_of: Integer, default: 600


### PR DESCRIPTION
Previously the `seven_zip_archive` extract action relied on the default timeout value of the `shell_out` function (default of 600 seconds). On slower machines the extraction of a 7.5Gb iso image can take over 10 minutes. This change adds an attribute `timeout` allowing users to change the timeout value, it still defaults to 600 seconds